### PR TITLE
Add query for all bibs with recent* issues

### DIFF
--- a/src/main/java/edu/cornell/library/integration/voyager/RecentIssues.java
+++ b/src/main/java/edu/cornell/library/integration/voyager/RecentIssues.java
@@ -43,7 +43,7 @@ public class RecentIssues {
       " ORDER BY si.issue_id DESC";
 
   private final static String newReceiptsBibsQuery =
-      "SELECT distinct li.bib_id, si.enumchron, si.receipt_date" +
+      "SELECT li.bib_id, si.enumchron, si.receipt_date" +
       "  FROM line_item li, line_item_copy_status lics, subscription s,"+
       "       component c, issues_received ir, serial_issues si"+
       " WHERE li.line_item_id = s.line_item_id"+
@@ -54,6 +54,30 @@ public class RecentIssues {
       "   AND ir.issue_id = si.issue_id"+
       "   AND ir.opac_suppressed = 1"+//note: 0 = true, 1 = false
       "   AND si.receipt_date > ?";
+
+  private final static String allBibsQuery =
+      "SELECT distinct li.bib_id" +
+      "  FROM line_item li, line_item_copy_status lics, subscription s,"+
+      "       component c, issues_received ir, serial_issues si"+
+      " WHERE li.line_item_id = s.line_item_id"+
+      "   AND li.line_item_id = lics.line_item_id"+
+      "   AND s.subscription_id = c.subscription_id"+
+      "   AND c.component_id = si.component_id"+
+      "   AND c.component_id = ir.component_id"+
+      "   AND ir.issue_id = si.issue_id"+
+      "   AND ir.opac_suppressed = 1";//note: 0 = true, 1 = false
+
+  public static Set<Integer> getAllAffectedBibs( Connection voyager ) throws SQLException {
+
+    Set<Integer> bibIds = new HashSet<>();
+    try (  PreparedStatement pstmt = voyager.prepareStatement(allBibsQuery);
+           ResultSet rs = pstmt.executeQuery()  ) {
+
+      while (rs.next()) bibIds.add( rs.getInt("bib_id") );
+    }
+    return bibIds;
+  }
+
 
   public static Map<Integer,Set<Change>> detectNewReceiptBibs(
       Connection voyager, Timestamp since, Map<Integer,Set<Change>> changes ) throws SQLException {

--- a/src/test/java/edu/cornell/library/integration/voyager/RecentIssuesTest.java
+++ b/src/test/java/edu/cornell/library/integration/voyager/RecentIssuesTest.java
@@ -3,8 +3,11 @@ package edu.cornell.library.integration.voyager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -37,11 +40,30 @@ public class RecentIssuesTest {
         prop.getProperty("voyagerDBUrl"),prop.getProperty("voyagerDBUser"),prop.getProperty("voyagerDBPass"));
   }
 
+//  @Test // Not a test
+  public void getAllLiveBibsWithRecentIssues() throws SQLException, FileNotFoundException, UnsupportedEncodingException {
+    Set<Integer> bibs = RecentIssues.getAllAffectedBibs( voyagerLive );
+    System.out.println("writing");
+    try( PrintWriter writer = new PrintWriter("all-recent-issue-bibs.txt", "UTF-8") ) {
+      for (Integer bib : bibs)
+        writer.println(bib);
+    }
+    System.out.println("written");
+  }
+
+  @Test
+  public void getAllBibsWithRecentIssues() throws SQLException {
+    Set<Integer> bibs = RecentIssues.getAllAffectedBibs( voyagerTest );
+    assertEquals(1,bibs.size());
+    assertTrue(bibs.contains(369282));
+  }
+
   @Test
   public void detectChanges() throws SQLException {
     Map<Integer,Set<Change>> changes = RecentIssues.detectNewReceiptBibs(
-        voyagerLive, Timestamp.valueOf("2018-05-08 08:00:00.0"),  new HashMap<Integer,Set<Change>>());
-    System.out.println(changes.toString());
+        voyagerTest, Timestamp.valueOf("2018-01-01 00:00:00.0"),  new HashMap<Integer,Set<Change>>());
+    assertTrue(changes.containsKey(369282));
+    assertEquals(4,changes.get(369282).size()); // 25 total issues to show, 4 in 2018
   }
 
   @Test


### PR DESCRIPTION
DISCOVERYACCESS-4157

*without regard to the date of receipt, recent issues are any that coded to show in the OPAC, and may in some cases be quite old.