### PR TITLE
Patch of March sprint changes: Make item change detection work with "Unavailable" nocirc annex items

### DIFF
--- a/src/main/java/edu/cornell/library/integration/voyager/Items.java
+++ b/src/main/java/edu/cornell/library/integration/voyager/Items.java
@@ -145,7 +145,7 @@ public class Items {
               Change c = new Change(Change.Type.CIRC,item.itemId,
                   String.join( " ",((item.enumeration!= null)?"("+item.enumeration+")":""),
                       item.status.code.values().iterator().next()),
-                  new Timestamp(item.status.date*1000),
+                  new Timestamp((item.status.date != null)?item.status.date*1000:System.currentTimeMillis()),
                   item.location.name);
               Integer bibId = bibRs.getInt(1);
               if (changes.containsKey(bibId))


### PR DESCRIPTION
We recently, in service of DISCOVERYACCESS-4881 adjusted the Solr availability representation for theoretically "Available" items that are not actually available for public use. As part of that, I removed the status date from the Solr representation entirely to keep it from displaying meaninglessly to patrons. This tripped up the process that detects status changes, as a timestamp associated with the change is a necessary component of queueing and logging the detected change. So, we'll just use the current timestamp as a stand-in for this Very Infrequent case. (Materials not available to the public don't circulate much.)