### PR TITLE
Adjust json serialization

### DIFF
--- a/src/main/java/edu/cornell/library/integration/availability/BibliographicSummary.java
+++ b/src/main/java/edu/cornell/library/integration/availability/BibliographicSummary.java
@@ -32,7 +32,7 @@ public class BibliographicSummary {
 
   @JsonIgnore static ObjectMapper mapper = new ObjectMapper();
   static {
-    mapper.setSerializationInclusion(Include.NON_EMPTY);
+    mapper.setSerializationInclusion(Include.NON_NULL);
   }
 
   public static Map<Integer,Set<Change>> detectChangedBibs(
@@ -105,11 +105,14 @@ public class BibliographicSummary {
         b.available = null;
       else
         b.available = false;
+      b.availAt = null;
     } else {
       b.available = true;
       for (String availLoc : b.availAt.keySet())
         b.unavailAt.remove(availLoc);
     }
+    if (b.unavailAt.isEmpty())
+      b.unavailAt = null;
 
     if ( ! b.online ) b.online = null;
 

--- a/src/main/java/edu/cornell/library/integration/availability/RecordsToSolr.java
+++ b/src/main/java/edu/cornell/library/integration/availability/RecordsToSolr.java
@@ -335,7 +335,7 @@ public class RecordsToSolr {
                     doc.addField("availability_facet", "Short Loan");
               BibliographicSummary b = BibliographicSummary.summarizeHoldingAvailability(holdings);
               doc.addField("availability_json", b.toJson());
-              if ( ! b.availAt.isEmpty() && ! b.unavailAt.isEmpty() )
+              if ( b.availAt != null && b.unavailAt != null )
                 doc.addField("availability_facet", "Avail and Unavail");
               Set<String> locationFacet = holdings.getLocationFacetValues();
               if (doc.containsKey("location"))


### PR DESCRIPTION
Had an issue testing the implementation of DISCOVERYACCESS-4873 because of a change in the json serialization behavior in the 2.9.9 jackson library. (DISCOVERYACCESS-4970). Specifically, the serialization now interprets the NON_EMPTY directive to drop key value pairs from a serialized hash when the value is "empty", even if the key is not, leading to dropping the hash entirely when all the values are "empty". (Why we need a hash when none of the values are populated is a story, but that's the situation here.)  I've switched to NON_NULL serialization, and am now more agressively using nulls when I don't want things to serialize.