### PR TITLE
Keep working on record delete queue while records found

### DIFF
--- a/src/main/java/edu/cornell/library/integration/availability/DeleteFromSolr.java
+++ b/src/main/java/edu/cornell/library/integration/availability/DeleteFromSolr.java
@@ -133,7 +133,7 @@ class DeleteFromSolr {
         deleteFromMRS.executeBatch();
         deleteFromIRS.executeBatch();
         System.out.println( countFound+" deleted");
-      } while ( countFound == 100 );
+      } while ( countFound > 0 );
       deleteFromQ.executeBatch();
       deleteFromGenQ.executeBatch();
       deleteFromAvailQ.executeBatch();


### PR DESCRIPTION
The original loop was grabbing 100 records from the queue, and deleting them, and then repeating unless the number processed from the last query was less than 100. If less than 100 records were retrieved it would suggest the end of the list had been found.

We later found that if a record was suppressed and added to the delete queue, then unsuppressed before the delete queue was executed, the records were being deleted when they were already unsuppressed. So by adding a check for active records and rejecting them as deletes, we often get less than 100 records to delete out of the query for 100 queue items.