### PR TITLE
Add two new Folio loan types to indexing logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,18 +60,6 @@
       <version>6.0.0</version>
     </dependency>
     <dependency>
-      <groupId>com.oracle</groupId>
-      <artifactId>ojdbc7</artifactId>
-      <version>12.1.0.2</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.marc4j</groupId>
-      <artifactId>marc4j</artifactId>
-      <version>2.6.0</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
     	<groupId>com.mchange</groupId>
     	<artifactId>c3p0</artifactId>
     	<version>0.9.5.4</version>

--- a/src/main/java/edu/cornell/library/integration/folio/LoanTypes.java
+++ b/src/main/java/edu/cornell/library/integration/folio/LoanTypes.java
@@ -47,6 +47,8 @@ public class LoanTypes {
     ILL2WK("ILL LOAN 2 Weeks"),
     ILL4WK("ILL LOAN 4 Weeks"),
     ILL6WK("ILL LOAN 6 Weeks"),
+    ILL8WK("ILL LOAN 8 Weeks"),
+   ILL10WK("ILL LOAN 10 Weeks"),
     EQ_X  ("Equipment extended loan"),
     EQ_L  ("Equipment long term"),
     EQ_S  ("Equipment short term"),


### PR DESCRIPTION
These are only associated with suppressed bibs, so should never be associated with any materials visible in Blacklight. DISCOVERYACCESS-8171