### PR TITLE
Suppress cover image for one instance

### DIFF
--- a/src/main/java/edu/cornell/library/integration/availability/ProcessAvailabilityQueue.java
+++ b/src/main/java/edu/cornell/library/integration/availability/ProcessAvailabilityQueue.java
@@ -428,6 +428,10 @@ public class ProcessAvailabilityQueue {
       doc.addField(solrField, true);
     }
 
+    // TODO REMOVE THIS WORKAROUND WHEN WE HAVE A BETTER MODEL FOR SUPPRESSING GOOGLE COVERS DACCESS-53
+    if ( bibId.equals("8930429") ) doc.removeField("oclc_id_display");
+
+
     WorksAndInventory.updateInventory( inventory, doc );
 
     List<SolrInputDocument> thisDocsCallNumberDocs =


### PR DESCRIPTION
DACCESS-53
This is a one-off that we WILL revert after completing the eventual plan for a more robust solution.