### PR TITLE
Add no_google_img_b to fields included in call number browse

### DIFF
--- a/solr/callnum/conf/schema.xml
+++ b/solr/callnum/conf/schema.xml
@@ -44,6 +44,7 @@
     <field name="pub_date_display"       type="string" indexed="false"  stored="true"  multiValued="false"/>
     <field name="oclc_id_display"        type="string" indexed="false"  stored="true"  multiValued="true"/>
     <field name="isbn_display"           type="string" indexed="false"  stored="true"  multiValued="true"/>
+    <field name="no_google_img_b"       type="boolean" indexed="false"  stored="true"  multiValued="false"/>
 
 
     <!-- Fields duplicated from Blacklight index, filtered to particular holdings -->

--- a/src/main/java/edu/cornell/library/integration/availability/CallNumberBrowse.java
+++ b/src/main/java/edu/cornell/library/integration/availability/CallNumberBrowse.java
@@ -32,7 +32,8 @@ class CallNumberBrowse {
       "fulltitle_vern_display",
       "pub_date_display",
       "isbn_display",
-      "oclc_id_display") ;
+      "oclc_id_display",
+      "no_google_img_b") ;
 
   private static final String lcCallNumberField = "lc_bib_display";
   private static final String urlField = "url_access_json";


### PR DESCRIPTION
DACCESS-53

(It turns out adding a field to the query doesn't help if it's not first in the index.)