### PR TITLE
Set most recent 2.x jackson json library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,10 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-     <groupId>com.fasterxml.jackson.core</groupId>
-     <artifactId>jackson-databind</artifactId>
-     <version>[2.9.9,3.0)</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.21.4</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>


### PR DESCRIPTION
Our jobs suddenly started crashing with the warning:

[WARNING] The POM for com.fasterxml.jackson.core:jackson-core:jar:2.22.0 is missing, no dependency information available

2.22 is a higher version than the most recent 2.x jackson currently available. I'm not sure why this version was being depended on, since the POM didn't specify that tightly, but pulling this back to a version that currently does exist allows the jobs to function.