### PR TITLE
Iterative metadb bib change detect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.4.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
       <version>3.41.2.2</version>

--- a/src/main/java/edu/cornell/library/integration/folio/Change.java
+++ b/src/main/java/edu/cornell/library/integration/folio/Change.java
@@ -65,6 +65,16 @@ public class Change implements Comparable<Change>{
     }
   }
 
+  public static void setCurrentToId(Long id, Connection inventory, String key ) throws SQLException {
+    
+    try (PreparedStatement pstmt = inventory.prepareStatement(
+        "REPLACE INTO updateCursorId ( cursor_name, current_to_id ) VALUES (?,?)")) {
+      pstmt.setString(1, key);
+      pstmt.setLong(2, id);
+      pstmt.executeUpdate();
+    }
+  }
+
   public static Long getMostRecentIdInMetadb(Connection metadb, String tableName) throws SQLException {
     try (Statement stmt = metadb.createStatement();
         ResultSet rs = stmt.executeQuery("SELECT MAX(__id) FROM "+tableName)) {

--- a/src/main/java/edu/cornell/library/integration/folio/Change.java
+++ b/src/main/java/edu/cornell/library/integration/folio/Change.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
@@ -36,12 +37,20 @@ public class Change implements Comparable<Change>{
     try (PreparedStatement pstmt = inventory.prepareStatement(
         "SELECT current_to_date FROM updateCursor WHERE cursor_name = ?")) {
       pstmt.setString(1, key);
-
       try (ResultSet rs = pstmt.executeQuery()) {
-        while (rs.next())
-          return rs.getTimestamp(1);
+        while (rs.next()) return rs.getTimestamp(1);
       }
-      
+    }
+    return null;
+  }
+
+  public static Long getCurrentToId( Connection inventory, String key ) throws SQLException {
+    try (PreparedStatement pstmt = inventory.prepareStatement(
+        "SELECT current_to_id FROM updateCursorId WHERE cursor_name = ?")) {
+      pstmt.setString(1, key);
+      try (ResultSet rs = pstmt.executeQuery()) {
+        while (rs.next())  return rs.getLong(1);
+      }
     }
     return null;
   }
@@ -54,6 +63,15 @@ public class Change implements Comparable<Change>{
       pstmt.setTimestamp(2, currentTo);
       pstmt.executeUpdate();
     }
+  }
+
+  public static Long getMostRecentIdInMetadb(Connection metadb, String tableName) throws SQLException {
+    try (Statement stmt = metadb.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT MAX(__id) FROM "+tableName)) {
+      while (rs.next())
+        return rs.getLong(1);
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/edu/cornell/library/integration/folio/ChangeDetector.java
+++ b/src/main/java/edu/cornell/library/integration/folio/ChangeDetector.java
@@ -93,40 +93,7 @@ public class ChangeDetector {
 
         if ( ! source.equals("MARC") ) continue INSTANCE;
 
-        String marc = null;
-        String srsQuery = "/source-storage/records/"+id+"/formatted?idType=INSTANCE";
-        try {
-          marc = folio.query(srsQuery).replaceAll("\\s*\\n\\s*", " ");
-        } catch (IOException e) {
-          // If MARC not found, wait 3 seconds and try one more time.
-          System.out.printf("Error retrieving MARC from SRS (%s): %s %s\n",e.getMessage(),hrid,id);
-          Thread.sleep(3_000);
-          try {
-            marc = folio.query("/source-storage/records/"+id+"/formatted?idType=INSTANCE")
-                .replaceAll("\\s*\\n\\s*", " ");
-          } catch (IOException e2) {
-            System.out.printf("Error retrieving MARC from SRS (%s): %s %s\n",e2.getMessage(),hrid,id);
-            continue INSTANCE;
-          }
-        }
-        if ( getPreviousBib == null )
-          getPreviousBib = inventory.prepareStatement(
-              "SELECT content FROM bibFolio WHERE instanceHrid = ?");
-        getPreviousBib.setString(1, hrid);
-        try ( ResultSet rs = getPreviousBib.executeQuery() ) {
-          while (rs.next()) if (rs.getString("content").equals(marc)) continue INSTANCE;
-        }
-
-        Matcher m = modDateP.matcher(marc);
-        Timestamp marcTimestamp = (m.matches())
-            ? Timestamp.from(Instant.parse(m.group(1).replace("+00:00","Z"))): null;
-        if ( replaceBib == null )
-          replaceBib = inventory.prepareStatement(
-              "REPLACE INTO bibFolio (instanceHrid,moddate,content) VALUES (?,?,?)");
-        replaceBib.setString(1, hrid);
-        replaceBib.setTimestamp(2, marcTimestamp);
-        replaceBib.setString(3, marc);
-        replaceBib.executeUpdate();
+        updateBibInCache(inventory, folio, hrid, id);
       }
     } while (changedInstances.size() == limit);
 
@@ -595,6 +562,77 @@ public class ChangeDetector {
     return changes;
   }
 
+
+  public static Map<String,Set<Change>> detectChangedBibs(
+      Connection inventory, Connection metadb, FolioClient folio, Long minId, Long maxId)
+          throws SQLException, AuthenticationException, InterruptedException {
+
+    Map<String,Set<Change>> changes = new HashMap<>();
+    Long lastId = maxId + 1;
+    try (PreparedStatement metadbQuery = metadb.prepareStatement(
+         "SELECT __id, external_hrid AS hrid, updated_date"+
+         "  FROM folio_source_record.records_lb__"+
+         " WHERE __id < ?"+
+         " ORDER BY __id desc"+
+         " LIMIT 100");
+        PreparedStatement bfQuery = inventory.prepareStatement(
+         "SELECT moddate FROM bibFolio WHERE instanceHrid = ?")) {
+      while (lastId > minId) {
+        System.out.format("%d %d %d\n", minId, lastId, maxId);
+        metadbQuery.setLong(1, lastId);
+        try(ResultSet mdbRs = metadbQuery.executeQuery()) {
+          while (mdbRs.next()) {
+            lastId = mdbRs.getLong("__id");
+            if (lastId < minId) break;
+            Timestamp mModdate = mdbRs.getTimestamp("updated_date");
+            mModdate.setNanos(0);
+            String hrid = mdbRs.getString("hrid");
+            bfQuery.setString(1, hrid);
+            try (ResultSet bfRs = bfQuery.executeQuery()) {
+              String changeType;
+              if (bfRs.next()) {
+                Timestamp iModdate = bfRs.getTimestamp("moddate");
+                boolean newerInMetadb = 1 ==  mModdate.compareTo(iModdate);
+                if ( ! newerInMetadb )  continue;
+                changeType = "Bib modified";
+                System.out.format( "%8s %s %s %d\n", hrid, mModdate, iModdate, mModdate.compareTo(iModdate));
+              } else {
+                // not in inventory
+                changeType = "Bib added";
+                System.out.format( "%8s %s\n", hrid, mModdate);
+                
+              }
+
+              String instanceId = null;
+              if (getInstanceIdByInstanceHrid == null)
+                getInstanceIdByInstanceHrid = inventory.prepareStatement(
+                    "SELECT id FROM instanceFolio WHERE hrid = ?");
+              getInstanceIdByInstanceHrid.setString(1,hrid);
+              try (ResultSet rs = getInstanceIdByInstanceHrid.executeQuery() ) {
+                while (rs.next()) instanceId = rs.getString(1);
+              }
+              if (instanceId == null) { System.out.println("Instance not in cache for hrid "+hrid); continue; }
+
+              String marc = updateBibInCache(inventory, folio, hrid, instanceId);
+              Change c = new Change(Change.Type.BIB,instanceId,changeType,
+                  mModdate,null,trackUserChange( inventory, marc ));
+              if ( ! changes.containsKey(hrid)) {
+                Set<Change> t = new HashSet<>();
+                t.add(c);
+                changes.put(hrid,t);
+              }
+              changes.get(hrid).add(c);
+            }
+          }
+        }
+        
+      }
+    }
+    return changes;
+    
+  }
+
+
   public static String trackUserChange( Connection inventory, String json ) throws SQLException {
     Matcher userM = modUserP.matcher(json);
     if ( userM.matches() ) {
@@ -608,6 +646,47 @@ public class ChangeDetector {
     }
     return null;
   }
+
+
+  private static String updateBibInCache(Connection inventory, FolioClient folio, String hrid, String id)
+      throws AuthenticationException, SQLException, InterruptedException {
+    String marc = null;
+    String srsQuery = "/source-storage/records/"+id+"/formatted?idType=INSTANCE";
+    try {
+      marc = folio.query(srsQuery).replaceAll("\\s*\\n\\s*", " ");
+    } catch (IOException e) {
+      // If MARC not found, wait 3 seconds and try one more time.
+      System.out.printf("Error retrieving MARC from SRS (%s): %s %s\n",e.getMessage(),hrid,id);
+      Thread.sleep(3_000);
+      try {
+        marc = folio.query("/source-storage/records/"+id+"/formatted?idType=INSTANCE")
+            .replaceAll("\\s*\\n\\s*", " ");
+      } catch (IOException e2) {
+        System.out.printf("Error retrieving MARC from SRS (%s): %s %s\n",e2.getMessage(),hrid,id);
+       return null;
+      }
+    }
+    if ( getPreviousBib == null )
+      getPreviousBib = inventory.prepareStatement(
+          "SELECT content FROM bibFolio WHERE instanceHrid = ?");
+    getPreviousBib.setString(1, hrid);
+    try ( ResultSet rs = getPreviousBib.executeQuery() ) {
+      while (rs.next()) if (rs.getString("content").equals(marc)) return null;
+    }
+
+    Matcher m = modDateP.matcher(marc);
+    Timestamp marcTimestamp = (m.matches())
+        ? Timestamp.from(Instant.parse(m.group(1).replace("+00:00","Z"))): null;
+    if ( replaceBib == null )
+      replaceBib = inventory.prepareStatement(
+          "REPLACE INTO bibFolio (instanceHrid,moddate,content) VALUES (?,?,?)");
+    replaceBib.setString(1, hrid);
+    replaceBib.setTimestamp(2, marcTimestamp);
+    replaceBib.setString(3, marc);
+    replaceBib.executeUpdate();
+    return marc;
+  }
+
 
   static Pattern modDateP = Pattern.compile("^.*\"updatedDate\" *: *\"([^\"]+)\".*$");
   static Pattern modUserP = Pattern.compile("^.*\"updatedByUserId\" *: *\"([^\"]+)\".*$");
@@ -629,6 +708,7 @@ public class ChangeDetector {
   static PreparedStatement replaceOrder = null;
   static PreparedStatement replaceOrderLine = null;
   static PreparedStatement getInstanceHridByInstanceId = null;
+  static PreparedStatement getInstanceIdByInstanceHrid = null;
   static PreparedStatement getItemParentage = null;
   static PreparedStatement getLoanParentage = null;
   static PreparedStatement getRequestParentage = null;

--- a/src/main/java/edu/cornell/library/integration/folio/ChangeDetector.java
+++ b/src/main/java/edu/cornell/library/integration/folio/ChangeDetector.java
@@ -578,7 +578,7 @@ public class ChangeDetector {
         PreparedStatement bfQuery = inventory.prepareStatement(
          "SELECT moddate FROM bibFolio WHERE instanceHrid = ?")) {
       while (lastId > minId) {
-        System.out.format("%d %d %d\n", minId, lastId, maxId);
+        System.out.format("Blacklight bib check: %d %d %d\n", minId, lastId, maxId);
         metadbQuery.setLong(1, lastId);
         try(ResultSet mdbRs = metadbQuery.executeQuery()) {
           while (mdbRs.next()) {
@@ -595,12 +595,8 @@ public class ChangeDetector {
                 boolean newerInMetadb = iModdate == null || 1 ==  mModdate.compareTo(iModdate);
                 if ( ! newerInMetadb )  continue;
                 changeType = "Bib modified";
-                System.out.format( "%8s %s %s %d\n", hrid, mModdate, iModdate, mModdate.compareTo(iModdate));
               } else {
-                // not in inventory
-                changeType = "Bib added";
-                System.out.format( "%8s %s\n", hrid, mModdate);
-                
+                changeType = "Bib added"; // not in inventory
               }
 
               String instanceId = null;

--- a/src/main/java/edu/cornell/library/integration/folio/ChangeDetector.java
+++ b/src/main/java/edu/cornell/library/integration/folio/ChangeDetector.java
@@ -592,7 +592,7 @@ public class ChangeDetector {
               String changeType;
               if (bfRs.next()) {
                 Timestamp iModdate = bfRs.getTimestamp("moddate");
-                boolean newerInMetadb = 1 ==  mModdate.compareTo(iModdate);
+                boolean newerInMetadb = iModdate == null || 1 ==  mModdate.compareTo(iModdate);
                 if ( ! newerInMetadb )  continue;
                 changeType = "Bib modified";
                 System.out.format( "%8s %s %s %d\n", hrid, mModdate, iModdate, mModdate.compareTo(iModdate));

--- a/src/main/java/edu/cornell/library/integration/folio/MonitorFolioChanges.java
+++ b/src/main/java/edu/cornell/library/integration/folio/MonitorFolioChanges.java
@@ -9,6 +9,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -24,6 +25,7 @@ import javax.naming.AuthenticationException;
 public class MonitorFolioChanges {
 
   private static final String CURRENT_TO_KEY = "avail";
+  private static final String METADB_CURSOR_KEY = "metadb_bib";
 
   public static void main(String[] args) throws IOException, SQLException, InterruptedException, AuthenticationException {
 
@@ -39,8 +41,10 @@ public class MonitorFolioChanges {
 
 
     try (
-        Connection inventory = DriverManager.getConnection(
-            prop.getProperty("databaseURLCurrent"),prop.getProperty("databaseUserCurrent"),prop.getProperty("databasePassCurrent"));
+        Connection inventory = DriverManager.getConnection( prop.getProperty("databaseURLCurrent"),
+        		prop.getProperty("databaseUserCurrent"),prop.getProperty("databasePassCurrent"));
+        Connection metadb = DriverManager.getConnection( prop.getProperty("databaseURLMetaDB"),
+        		prop.getProperty("databaseUserMetaDB"),prop.getProperty("databasePassMetaDB"));
         PreparedStatement queueAvail = inventory.prepareStatement
             ("INSERT INTO availQueue ( hrid, priority, cause, record_date ) VALUES (?,?,?,?)");
         PreparedStatement queueGen = inventory.prepareStatement
@@ -60,8 +64,17 @@ public class MonitorFolioChanges {
         System.out.println("No starting timestamp in DB, defaulting to 10 hours ago.");
       }
       System.out.println(time);
+      Long metadbCursor = Change.getCurrentToId(inventory, METADB_CURSOR_KEY);
+      if (metadbCursor == null) {
+        System.out.println("MetaDB bib cursor missing.");
+        System.exit(1);
+      }
+      System.out.println(metadbCursor);
+      try (Statement stmt = inventory.createStatement()) {
+        stmt.executeUpdate("SET time_zone = '+00:00'");
+      }
 
-      while ( true ) {
+      for (int i = 0; i < 500_000; i++){
         Timestamp newTime = new Timestamp(Calendar.getInstance().getTime().getTime()-10_000);//now minus 10 seconds
         final Timestamp since = time;
 
@@ -82,6 +95,14 @@ public class MonitorFolioChanges {
             queueAvail, getTitle, getUserChangeTotals );
         queueForIndex( ChangeDetector.detectChangedOrders( inventory, folio, since ),
             queueAvail, getTitle, getUserChangeTotals );
+
+        if (i % 10 == 0) {
+          Long newCursor = Change.getMostRecentIdInMetadb(metadb, "folio_source_record.records_lb");
+          System.out.println(newCursor);
+          queueForIndex( ChangeDetector.detectChangedBibs(inventory, metadb, folio, metadbCursor, newCursor),
+              queueGen, getTitle, getUserChangeTotals);
+          metadbCursor = newCursor;
+        }
 
         Thread.sleep(12_000); //12 seconds
         time = newTime;

--- a/src/main/java/edu/cornell/library/integration/folio/MonitorFolioChanges.java
+++ b/src/main/java/edu/cornell/library/integration/folio/MonitorFolioChanges.java
@@ -96,12 +96,12 @@ public class MonitorFolioChanges {
         queueForIndex( ChangeDetector.detectChangedOrders( inventory, folio, since ),
             queueAvail, getTitle, getUserChangeTotals );
 
-        if (i % 10 == 0) {
+        if ((i % 10) == 0) {
           Long newCursor = Change.getMostRecentIdInMetadb(metadb, "folio_source_record.records_lb");
-          System.out.println(newCursor);
           queueForIndex( ChangeDetector.detectChangedBibs(inventory, metadb, folio, metadbCursor, newCursor),
               queueGen, getTitle, getUserChangeTotals);
           metadbCursor = newCursor;
+          Change.setCurrentToId( metadbCursor, inventory, METADB_CURSOR_KEY );
         }
 
         Thread.sleep(12_000); //12 seconds


### PR DESCRIPTION
Add an iterative check for bib updates that might have been missed in Folio querying using metadb.
Because the marc table in metadb uses an autoincrement __id field to identify each version of each bib, we're able to ensure we check every bib update using that rather than timestamps to check for new updates. 
DACCESS-878